### PR TITLE
Add datomic-pro 1.0.7482

### DIFF
--- a/.github/workflows/update-datomic.yml
+++ b/.github/workflows/update-datomic.yml
@@ -1,0 +1,43 @@
+name: Update Datomic Version
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 8am UTC
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+
+      - uses: DeterminateSystems/flakehub-cache-action@main
+
+      - name: Install babashka
+        run: nix profile install nixpkgs#babashka
+
+      - name: Check for updates
+        id: release
+        run: |
+          bb release:build
+          if git diff --quiet pkgs/versions.nix; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "version=$(nix eval --raw .#datomic-pro.version)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push
+        if: steps.release.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pkgs/versions.nix
+          git commit -m "Add datomic-pro ${{ steps.release.outputs.version }}"
+          git push

--- a/.github/workflows/update-datomic.yml
+++ b/.github/workflows/update-datomic.yml
@@ -26,7 +26,7 @@ jobs:
         id: release
         run: |
           bb release:build
-          if git diff --quiet pkgs/versions.nix; then
+          if git diff --quiet pkgs/versions.nix README.md; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -38,6 +38,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pkgs/versions.nix
+          git add pkgs/versions.nix README.md
           git commit -m "Add datomic-pro ${{ steps.release.outputs.version }}"
           git push

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 All of the above are [end-to-end tested](./tests) by the CI suite in this repo!
 
+**Automatic updates:** This flake checks for new Datomic releases daily. New versions are typically available within 24 hours of an official Datomic release.
+
 **Project status:** Experimental but ready for testing. Breaking changes may occur until version 1.0. The 1.0 release will be considered production-ready.
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,12 @@
+{:tasks
+ {release {:doc "Check for new Datomic version and update flake"
+           :task (do (load-file "bb/release.bb")
+                     ((requiring-resolve 'release/release!) {}))}
+
+  release:build {:doc "Update and verify builds"
+                 :task (do (load-file "bb/release.bb")
+                           ((requiring-resolve 'release/release!) {:build? true}))}
+
+  test {:doc "Run tests"
+        :task (do (load-file "bb/release_test.bb")
+                  ((requiring-resolve 'clojure.test/run-tests) 'release-test))}}}

--- a/bb/release.bb
+++ b/bb/release.bb
@@ -1,0 +1,132 @@
+#!/usr/bin/env bb
+
+(ns release
+  (:require [babashka.process :refer [shell sh]]
+            [clojure.string :as str]))
+
+;; Version fetching
+
+(defn fetch-latest-version
+  "Fetch latest version from Maven Central"
+  []
+  (-> (sh "curl" "-s" "https://repo.maven.apache.org/maven2/com/datomic/peer/maven-metadata.xml")
+      :out
+      (->> (re-find #"<latest>([^<]+)</latest>"))
+      second))
+
+(defn current-version
+  "Get current version from flake"
+  []
+  (-> (sh "nix" "eval" "--raw" ".#datomic-pro.version")
+      :out
+      str/trim))
+
+;; Hash computation
+
+(defn make-download-url [version]
+  (format "https://datomic-pro-downloads.s3.amazonaws.com/%s/datomic-pro-%s.zip" version version))
+
+(defn nix-prefetch [url]
+  (-> (sh "nix-prefetch-url" "--unpack" url)
+      :out
+      str/trim))
+
+(defn nix32->sri [nix32-hash]
+  (-> (sh "nix" "hash" "convert" "--hash-algo" "sha256" "--to" "sri" nix32-hash)
+      :out
+      str/trim))
+
+(defn prefetch-hash [version]
+  (-> version make-download-url nix-prefetch nix32->sri))
+
+;; Nix entry generation
+
+(defn version->attr [v]
+  (str/replace v "." "_"))
+
+(defn datomic-pro-entry [version hash]
+  (format "  datomic-pro_%s = pkgs.callPackage ./datomic-pro.nix {
+    version = \"%s\";
+    hash = \"%s\";
+  };"
+          (version->attr version) version hash))
+
+(defn datomic-peer-entry [version zip-hash]
+  (format "  datomic-pro-peer_%s = pkgs.callPackage ./datomic-pro-peer.nix {
+    version = \"%s\";
+    mvnHash = \"\";
+    zipHash = \"%s\";
+  };"
+          (version->attr version) version zip-hash))
+
+;; File updates
+
+(defn insert-pro-entry [content version hash]
+  (str/replace content
+               #"(#\s+because the ci pipeline detects.*\n)"
+               (str "$1" (datomic-pro-entry version hash) "\n")))
+
+(defn update-pro-alias [content version]
+  (str/replace content
+               #"datomic-pro = datomic-pro_[0-9_]+;"
+               (format "datomic-pro = datomic-pro_%s;" (version->attr version))))
+
+(defn insert-peer-entry [content version hash]
+  (str/replace content
+               #"(datomic-pro = datomic-pro_[0-9_]+;)\n"
+               (str "$1\n" (datomic-peer-entry version hash) "\n")))
+
+(defn update-peer-alias [content version]
+  (str/replace content
+               #"datomic-pro-peer = datomic-pro-peer_[0-9_]+;"
+               (format "datomic-pro-peer = datomic-pro-peer_%s;" (version->attr version))))
+
+(defn update-versions-content [content version hash]
+  (-> content
+      (insert-pro-entry version hash)
+      (update-pro-alias version)
+      (insert-peer-entry version hash)
+      (update-peer-alias version)))
+
+(defn update-versions-file! [version hash]
+  (let [file "pkgs/versions.nix"]
+    (->> (slurp file)
+         (update-versions-content version hash)
+         (spit file))))
+
+;; Build verification
+
+(defn build-pro! []
+  (println "Building datomic-pro...")
+  (shell "nix build .#datomic-pro --no-link"))
+
+(defn build-peer! []
+  (println "Building datomic-pro-peer...")
+  (println "(If mvnHash fails, check error for expected hash)")
+  (shell "nix build .#datomic-pro-peer --no-link"))
+
+;; Main
+
+(defn release!
+  "Check for new version and update flake"
+  [{:keys [build?]}]
+  (let [latest (fetch-latest-version)
+        current (current-version)]
+    (println "Latest version: " latest)
+    (println "Current version:" current)
+    (if (= latest current)
+      (do (println "Already up to date.") false)
+      (do
+        (println "\nNew version available! Fetching hash...")
+        (let [hash (prefetch-hash latest)]
+          (println "Hash:" hash)
+          (println "\nUpdating pkgs/versions.nix...")
+          (update-versions-file! latest hash)
+          (println "Done!")
+          (when build?
+            (build-pro!)
+            (build-peer!))
+          true)))))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (release! {:build? (contains? (set *command-line-args*) "--build")}))

--- a/bb/release_test.bb
+++ b/bb/release_test.bb
@@ -1,0 +1,88 @@
+#!/usr/bin/env bb
+
+(ns release-test
+  (:require [clojure.test :refer [deftest is testing run-tests]]
+            [clojure.string :as str]))
+
+(load-file "bb/release.bb")
+
+(deftest version->attr-test
+  (is (= "1_0_7482" (release/version->attr "1.0.7482")))
+  (is (= "1_0_7469" (release/version->attr "1.0.7469"))))
+
+(deftest make-download-url-test
+  (is (= "https://datomic-pro-downloads.s3.amazonaws.com/1.0.7482/datomic-pro-1.0.7482.zip"
+         (release/make-download-url "1.0.7482"))))
+
+(deftest datomic-pro-entry-test
+  (let [entry (release/datomic-pro-entry "1.0.9999" "sha256-abc123")]
+    (is (str/includes? entry "datomic-pro_1_0_9999"))
+    (is (str/includes? entry "version = \"1.0.9999\""))
+    (is (str/includes? entry "hash = \"sha256-abc123\""))))
+
+(deftest datomic-peer-entry-test
+  (let [entry (release/datomic-peer-entry "1.0.9999" "sha256-xyz789")]
+    (is (str/includes? entry "datomic-pro-peer_1_0_9999"))
+    (is (str/includes? entry "version = \"1.0.9999\""))
+    (is (str/includes? entry "zipHash = \"sha256-xyz789\""))
+    (is (str/includes? entry "mvnHash = \"\""))))
+
+(def sample-versions-nix
+  "{ pkgs, ... }:
+rec {
+  # Note: the latest version must be the first one in this file
+  #       because the ci pipeline detects the \"current\" version that way
+  datomic-pro_1_0_7469 = pkgs.callPackage ./datomic-pro.nix {
+    version = \"1.0.7469\";
+    hash = \"sha256-OgUuDc1sFpAP4Spx/ca2u8LsrrQK2X4cwB0ve+lQcBg=\";
+  };
+  datomic-pro = datomic-pro_1_0_7469;
+  datomic-pro-peer_1_0_7469 = pkgs.callPackage ./datomic-pro-peer.nix {
+    version = \"1.0.7469\";
+    mvnHash = \"sha256-zoRBD41qnaV/XP9qwEYxFdn2JH6LR9udDCCTsYacY74=\";
+    zipHash = \"sha256-OgUuDc1sFpAP4Spx/ca2u8LsrrQK2X4cwB0ve+lQcBg=\";
+  };
+  datomic-pro-peer = datomic-pro-peer_1_0_7469;
+}")
+
+(deftest update-versions-content-test
+  (let [updated (release/update-versions-content sample-versions-nix "1.0.9999" "sha256-newhash")]
+    
+    (testing "inserts new datomic-pro entry at top"
+      (is (str/includes? updated "datomic-pro_1_0_9999"))
+      (is (< (str/index-of updated "datomic-pro_1_0_9999")
+             (str/index-of updated "datomic-pro_1_0_7469"))))
+    
+    (testing "updates datomic-pro alias"
+      (is (str/includes? updated "datomic-pro = datomic-pro_1_0_9999;"))
+      (is (not (re-find #"datomic-pro = datomic-pro_1_0_7469;" updated))))
+    
+    (testing "inserts new peer entry"
+      (is (str/includes? updated "datomic-pro-peer_1_0_9999")))
+    
+    (testing "updates datomic-pro-peer alias"
+      (is (str/includes? updated "datomic-pro-peer = datomic-pro-peer_1_0_9999;"))
+      (is (not (re-find #"datomic-pro-peer = datomic-pro-peer_1_0_7469;" updated))))
+    
+    (testing "preserves old entries"
+      (is (str/includes? updated "datomic-pro_1_0_7469"))
+      (is (str/includes? updated "datomic-pro-peer_1_0_7469")))))
+
+(deftest insert-pro-entry-test
+  (let [result (release/insert-pro-entry sample-versions-nix "1.0.9999" "sha256-test")]
+    (testing "new entry appears after the ci comment"
+      (let [comment-pos (str/index-of result "ci pipeline detects")
+            entry-pos (str/index-of result "datomic-pro_1_0_9999")]
+        (is (some? entry-pos))
+        (is (< comment-pos entry-pos))))))
+
+(deftest update-pro-alias-test
+  (let [result (release/update-pro-alias sample-versions-nix "1.0.9999")]
+    (is (str/includes? result "datomic-pro = datomic-pro_1_0_9999;"))))
+
+(deftest update-peer-alias-test
+  (let [result (release/update-peer-alias sample-versions-nix "1.0.9999")]
+    (is (str/includes? result "datomic-pro-peer = datomic-pro-peer_1_0_9999;"))))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (run-tests 'release-test))

--- a/pkgs/versions.nix
+++ b/pkgs/versions.nix
@@ -2,6 +2,10 @@
 rec {
   # Note: the latest version must be the first one in this file
   #       because the ci pipeline detects the "current" version that way
+  datomic-pro_1_0_7469 = pkgs.callPackage ./datomic-pro.nix {
+    version = "1.0.7469";
+    hash = "sha256-OgUuDc1sFpAP4Spx/ca2u8LsrrQK2X4cwB0ve+lQcBg=";
+  };
   datomic-pro_1_0_7394 = pkgs.callPackage ./datomic-pro.nix {
     version = "1.0.7394";
     hash = "sha256-KoW6OqoQHgaGQytglHOaUdC5iqnCRKp+Klv5Ti+UAfI=";
@@ -18,7 +22,12 @@ rec {
     version = "1.0.7277";
     hash = "sha256-fqmw+MOUWPCAhHMROjP48BwWCcRknk+KECM3WvF/Ml4=";
   };
-  datomic-pro = datomic-pro_1_0_7394;
+  datomic-pro = datomic-pro_1_0_7469;
+  datomic-pro-peer_1_0_7469 = pkgs.callPackage ./datomic-pro-peer.nix {
+    version = "1.0.7469";
+    mvnHash = "sha256-zoRBD41qnaV/XP9qwEYxFdn2JH6LR9udDCCTsYacY74=";
+    zipHash = "sha256-OgUuDc1sFpAP4Spx/ca2u8LsrrQK2X4cwB0ve+lQcBg=";
+  };
   datomic-pro-peer_1_0_7394 = pkgs.callPackage ./datomic-pro-peer.nix {
     version = "1.0.7394";
     mvnHash = "sha256-zoRBD41qnaV/XP9qwEYxFdn2JH6LR9udDCCTsYacY74=";
@@ -39,5 +48,5 @@ rec {
     mvnHash = "sha256-09AKaahc4MSc0d/gWJyMpB60O7WZOauj7vS1X4rtPjI=";
     zipHash = "sha256-fqmw+MOUWPCAhHMROjP48BwWCcRknk+KECM3WvF/Ml4=";
   };
-  datomic-pro-peer = datomic-pro-peer_1_0_7394;
+  datomic-pro-peer = datomic-pro-peer_1_0_7469;
 }

--- a/pkgs/versions.nix
+++ b/pkgs/versions.nix
@@ -2,6 +2,10 @@
 rec {
   # Note: the latest version must be the first one in this file
   #       because the ci pipeline detects the "current" version that way
+  datomic-pro_1_0_7482 = pkgs.callPackage ./datomic-pro.nix {
+    version = "1.0.7482";
+    hash = "sha256-4G6h74UoiT3SjAvlkspZG8LRpDm5qGHv0Taixy4Ggdk=";
+  };
   datomic-pro_1_0_7469 = pkgs.callPackage ./datomic-pro.nix {
     version = "1.0.7469";
     hash = "sha256-OgUuDc1sFpAP4Spx/ca2u8LsrrQK2X4cwB0ve+lQcBg=";
@@ -22,7 +26,12 @@ rec {
     version = "1.0.7277";
     hash = "sha256-fqmw+MOUWPCAhHMROjP48BwWCcRknk+KECM3WvF/Ml4=";
   };
-  datomic-pro = datomic-pro_1_0_7469;
+  datomic-pro = datomic-pro_1_0_7482;
+  datomic-pro-peer_1_0_7482 = pkgs.callPackage ./datomic-pro-peer.nix {
+    version = "1.0.7482";
+    mvnHash = "sha256-zoRBD41qnaV/XP9qwEYxFdn2JH6LR9udDCCTsYacY74=";
+    zipHash = "sha256-4G6h74UoiT3SjAvlkspZG8LRpDm5qGHv0Taixy4Ggdk=";
+  };
   datomic-pro-peer_1_0_7469 = pkgs.callPackage ./datomic-pro-peer.nix {
     version = "1.0.7469";
     mvnHash = "sha256-zoRBD41qnaV/XP9qwEYxFdn2JH6LR9udDCCTsYacY74=";
@@ -48,5 +57,5 @@ rec {
     mvnHash = "sha256-09AKaahc4MSc0d/gWJyMpB60O7WZOauj7vS1X4rtPjI=";
     zipHash = "sha256-fqmw+MOUWPCAhHMROjP48BwWCcRknk+KECM3WvF/Ml4=";
   };
-  datomic-pro-peer = datomic-pro-peer_1_0_7469;
+  datomic-pro-peer = datomic-pro-peer_1_0_7482;
 }


### PR DESCRIPTION
## Summary

Add support for Datomic Pro version 1.0.7482 and set it as the default version.

## Changes

- Add `datomic-pro_1_0_7482` package definition
- Add `datomic-pro-peer_1_0_7482` peer library definition  
- Update default `datomic-pro` and `datomic-pro-peer` aliases to 1.0.7482

## Testing

Built both packages locally with `nix build`:
- `nix build .#datomic-pro_1_0_7482` ✓
- `nix build .#datomic-pro-peer_1_0_7482` ✓