### PR TITLE
Add automatic version bumping and make package option required

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,31 @@
+---
+name: Auto Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'auto-update')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from CHANGELOG
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^## v[0-9]' CHANGELOG.md | sed 's/## \(v[0-9.]*\).*/\1/')
+          echo "tag=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          git config user.name "Casey Link"
+          git config user.email "14830+Ramblurr@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-datomic.yml
+++ b/.github/workflows/update-datomic.yml
@@ -1,0 +1,46 @@
+---
+name: Update Datomic Version
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/flakehub-cache-action@main
+
+      - name: Check for updates
+        id: release
+        run: |
+          nix develop --command bb release:build
+          if git diff --quiet pkgs/versions.nix README.md CHANGELOG.md nixos-modules/datomic-pro.nix; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "version=$(nix eval --raw .#datomic-pro.version)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR
+        if: steps.release.outputs.changed == 'true'
+        run: |
+          BRANCH="auto-update/datomic-${{ steps.release.outputs.version }}"
+          git config user.name "Casey Link"
+          git config user.email "14830+Ramblurr@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add pkgs/versions.nix README.md CHANGELOG.md nixos-modules/datomic-pro.nix
+          git commit -m "Add datomic-pro ${{ steps.release.outputs.version }}"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "Add datomic-pro ${{ steps.release.outputs.version }}" \
+            --body "Automated update to Datomic Pro ${{ steps.release.outputs.version }}" \
+            --label "auto-update"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - NixOS module: The `services.datomic-pro.package` option is now required. You must explicitly pin your Datomic version. This change prevents unexpected upgrades that could affect your data.
 
+### Added
+
+- Add automatic version bumping. Thanks to @licht1stein for contributing.
+
 ## v0.10.0 (2026-02-03)
 
 This is a version bump release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Breaking
+
+- NixOS module: The `services.datomic-pro.package` option is now required. You must explicitly pin your Datomic version. This change prevents unexpected upgrades that could affect your data.
+
 ## v0.10.0 (2026-02-03)
 
 This is a version bump release:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ And for peer:
 -  `pkgs.datomic-pro-peer_1_0_7364`
 -  `pkgs.datomic-pro-peer_1_0_7277`
 
+New versions are typically available within 24 hours of an official Datomic release.
+
 ## Usage - NixOS Module
 
 ### `flake.nix`

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,13 @@
+{:paths ["scripts"]
+ :tasks
+ {:requires ([release :as release]
+             [release-test :as release-test]
+             [clojure.test :as test])
+  release {:doc "Check for new Datomic version and update flake"
+           :task (release/release! {})}
+
+  release:build {:doc "Update and verify builds"
+                 :task (release/release! {:build? true})}
+
+  test {:doc "Run tests"
+        :task (test/run-tests 'release-test)}}}

--- a/scripts/release.clj
+++ b/scripts/release.clj
@@ -1,0 +1,295 @@
+(ns release
+  (:require [babashka.process :refer [shell]]
+            [clojure.string :as str]))
+
+(defn fetch-latest-version
+  []
+  (let [{:keys [out exit]}
+        (shell {:out :string :err :string}
+               "curl" "-s"
+               "https://repo.maven.apache.org/maven2/com/datomic/peer/maven-metadata.xml")]
+    (when (zero? exit)
+      (second (re-find #"<latest>([^<]+)</latest>" out)))))
+
+(defn current-version
+  []
+  (let [{:keys [out exit]}
+        (shell {:out :string :err :string}
+               "nix" "eval" "--raw" ".#datomic-pro.version")]
+    (when (zero? exit)
+      (str/trim out))))
+
+(defn prefetch-hash
+  [version]
+  (let [url (format "https://datomic-pro-downloads.s3.amazonaws.com/%s/datomic-pro-%s.zip"
+                    version version)
+        {:keys [out exit]}
+        (shell {:out :string :err :string}
+               "nix-prefetch-url" "--type" "sha256" url)]
+    (when (zero? exit)
+      (let [base32-hash (str/trim out)
+            {:keys [out exit]}
+            (shell {:out :string :err :string}
+                   "nix" "hash" "convert" "--hash-algo" "sha256" "--to" "sri" base32-hash)]
+        (when (zero? exit)
+          (str/trim out))))))
+
+(defn version->attr
+  [version]
+  (str/replace version "." "_"))
+
+(defn datomic-pro-entry
+  [version hash]
+  (let [attr (version->attr version)]
+    (format "  datomic-pro_%s = pkgs.callPackage ./datomic-pro.nix {
+    version = \"%s\";
+    hash = \"%s\";
+  };" attr version hash)))
+
+(defn datomic-peer-entry
+  [version mvn-hash zip-hash]
+  (let [attr (version->attr version)]
+    (format "  datomic-pro-peer_%s = pkgs.callPackage ./datomic-pro-peer.nix {
+    version = \"%s\";
+    mvnHash = \"%s\";
+    zipHash = \"%s\";
+  };" attr version mvn-hash zip-hash)))
+
+(defn extract-versions
+  [content]
+  (let [matches (re-seq #"datomic-pro_(\d+_\d+_\d+)\s*=" content)]
+    (->> matches
+         (map second)
+         distinct
+         (map #(str/replace % "_" "."))
+         vec)))
+
+(defn extract-peer-versions
+  [content]
+  (let [matches (re-seq #"datomic-pro-peer_(\d+_\d+_\d+)\s*=" content)]
+    (->> matches
+         (map second)
+         distinct
+         (map #(str/replace % "_" "."))
+         vec)))
+
+(defn update-versions-content
+  [content new-version zip-hash mvn-hash]
+  (let [attr (version->attr new-version)
+        new-pro-entry (datomic-pro-entry new-version zip-hash)
+        new-peer-entry (datomic-peer-entry new-version mvn-hash zip-hash)
+        lines (str/split-lines content)
+        header-end (inc (.indexOf lines "rec {"))
+        comment-end (loop [i header-end]
+                      (if (str/starts-with? (str/trim (nth lines i "")) "#")
+                        (recur (inc i))
+                        i))
+        before-entries (subvec (vec lines) 0 comment-end)
+        rest-content (str/join "\n" (subvec (vec lines) comment-end))
+        pro-alias-pattern #"(\s*datomic-pro\s*=\s*)datomic-pro_\d+_\d+_\d+;"
+        peer-alias-pattern #"(\s*datomic-pro-peer\s*=\s*)datomic-pro-peer_\d+_\d+_\d+;"
+        first-peer-pattern #"(?m)^(\s*datomic-pro-peer_\d+_\d+_\d+\s*=)"
+        updated-rest (-> rest-content
+                         (str/replace pro-alias-pattern
+                                      (str "$1datomic-pro_" attr ";"))
+                         (str/replace peer-alias-pattern
+                                      (str "$1datomic-pro-peer_" attr ";"))
+                         (str/replace-first first-peer-pattern
+                                            (str new-peer-entry "\n$1")))]
+    (str (str/join "\n" before-entries)
+         "\n"
+         new-pro-entry
+         "\n"
+         updated-rest)))
+
+(defn update-readme-content
+  [content versions peer-versions new-version]
+  (let [attr (version->attr new-version)
+        all-versions (distinct (cons new-version versions))
+        all-peer-versions (distinct (cons new-version peer-versions))
+        pro-list (->> all-versions
+                      (map-indexed (fn [i v]
+                                     (if (zero? i)
+                                       (format "-  `pkgs.datomic-pro_%s` (latest)" (version->attr v))
+                                       (format "-  `pkgs.datomic-pro_%s`" (version->attr v)))))
+                      (str/join "\n"))
+        peer-list (->> all-peer-versions
+                       (map-indexed (fn [i v]
+                                      (if (zero? i)
+                                        (format "-  `pkgs.datomic-pro-peer_%s` (latest)" (version->attr v))
+                                        (format "-  `pkgs.datomic-pro-peer_%s`" (version->attr v)))))
+                       (str/join "\n"))
+        pro-section-pattern #"(?s)(`pkgs\.datomic-pro` will always be the latest release, but the following specific versions are also available:\n\n)(-  `pkgs\.datomic-pro_[^`]+`[^\n]*\n)+"
+        peer-section-pattern #"(?s)(And for peer:\n\n)(-  `pkgs\.datomic-pro-peer_[^`]+`[^\n]*\n)+"
+        docker-tag-pattern #"ghcr\.io/outskirtslabs/datomic-pro:\d+\.\d+\.\d+"
+        config-pkg-pattern #"package = pkgs\.datomic-pro_\d+_\d+_\d+;"]
+    (-> content
+        (str/replace pro-section-pattern (str "$1" pro-list "\n"))
+        (str/replace peer-section-pattern (str "$1" peer-list "\n"))
+        (str/replace docker-tag-pattern (str "ghcr.io/outskirtslabs/datomic-pro:" new-version))
+        (str/replace config-pkg-pattern (str "package = pkgs.datomic-pro_" attr ";")))))
+
+(defn next-flake-version
+  [changelog-content]
+  (let [version-pattern #"## v(\d+)\.(\d+)\.(\d+)"
+        match (re-find version-pattern changelog-content)]
+    (when match
+      (let [major (parse-long (nth match 1))
+            minor (parse-long (nth match 2))]
+        (format "v%d.%d.0" major (inc minor))))))
+
+(defn generate-changelog-entry
+  [flake-version datomic-version versions peer-versions date]
+  (let [all-versions (distinct (cons datomic-version versions))
+        all-peer-versions (distinct (cons datomic-version peer-versions))
+        pro-list (->> all-versions
+                      (map-indexed (fn [i v]
+                                     (if (zero? i)
+                                       (format "-  `pkgs.datomic-pro_%s` (latest)" (version->attr v))
+                                       (format "-  `pkgs.datomic-pro_%s`" (version->attr v)))))
+                      (str/join "\n"))
+        peer-list (->> all-peer-versions
+                       (map-indexed (fn [i v]
+                                      (if (zero? i)
+                                        (format "-  `pkgs.datomic-pro-peer_%s` (latest)" (version->attr v))
+                                        (format "-  `pkgs.datomic-pro-peer_%s`" (version->attr v)))))
+                       (str/join "\n"))]
+    (format "## %s (%s)
+
+This is a version bump release:
+
+- Added package versions for [version %s](https://docs.datomic.com/changes/pro.html#%s)
+
+`pkgs.datomic-pro` will always be the latest release, but the following specific versions are also available:
+
+%s
+
+And for peer:
+
+%s"
+            flake-version date datomic-version datomic-version pro-list peer-list)))
+
+(defn has-unreleased-content?
+  [content]
+  (let [lines (str/split-lines content)
+        unreleased-idx (->> lines
+                            (map-indexed vector)
+                            (filter #(str/starts-with? (second %) "## [UNRELEASED]"))
+                            first
+                            first)
+        next-version-idx (->> lines
+                              (map-indexed vector)
+                              (filter #(and (> (first %) (or unreleased-idx -1))
+                                            (re-matches #"## v\d+\.\d+\.\d+.*" (second %))))
+                              first
+                              first)]
+    (when (and unreleased-idx next-version-idx)
+      (let [between (subvec (vec lines) (inc unreleased-idx) next-version-idx)]
+        (some #(not (str/blank? %)) between)))))
+
+(defn update-changelog-content
+  [content flake-version datomic-version versions peer-versions date]
+  (when (has-unreleased-content? content)
+    (throw (ex-info "CHANGELOG.md has unreleased notes. Please release those manually first."
+                    {:type :unreleased-content})))
+  (let [entry (generate-changelog-entry flake-version datomic-version versions peer-versions date)
+        before-version-pattern #"(?m)^(## v\d+\.\d+\.\d+)"]
+    (str/replace-first content before-version-pattern
+                       (str entry "\n\n$1"))))
+
+(defn today-date
+  []
+  (let [now (java.time.LocalDate/now)
+        formatter (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd")]
+    (.format now formatter)))
+
+(defn update-nixos-module-content
+  [content versions]
+  (let [latest-5 (take 5 versions)
+        related-packages (->> latest-5
+                              (map #(str "          \"datomic-pro_" (version->attr %) "\""))
+                              (str/join "\n"))
+        related-pattern #"(?s)(relatedPackages = \[\n)(.*?)(\n\s*\];)"]
+    (str/replace content related-pattern (str "$1" related-packages "$3"))))
+
+(defn get-mvn-hash
+  [version zip-hash]
+  (println "Building peer package to get mvnHash (this will fail and show the correct hash)...")
+  (let [{:keys [err exit]}
+        (shell {:out :string :err :string :continue true}
+               "nix" "build" (str ".#datomic-pro-peer_" (version->attr version)))]
+    (if (zero? exit)
+      (do
+        (println "Build succeeded unexpectedly - mvnHash may not have changed")
+        nil)
+      (let [hash-match (re-find #"got:\s+(sha256-[A-Za-z0-9+/=]+)" err)]
+        (when hash-match
+          (second hash-match))))))
+
+(defn release!
+  [{:keys [build?]}]
+  (println "Checking for new Datomic version...")
+  (let [latest (fetch-latest-version)
+        current (current-version)]
+    (println "Latest:" latest)
+    (println "Current:" current)
+    (if (= latest current)
+      (println "Already up to date!")
+      (do
+        (println "New version available:" latest)
+        (println "Fetching zip hash...")
+        (let [zip-hash (prefetch-hash latest)]
+          (if-not zip-hash
+            (println "Failed to fetch zip hash!")
+            (do
+              (println "Zip hash:" zip-hash)
+              (println "Updating versions.nix...")
+              (let [versions-path "pkgs/versions.nix"
+                    versions-content (slurp versions-path)
+                    existing-versions (extract-versions versions-content)
+                    existing-peer-versions (extract-peer-versions versions-content)
+                    mvn-hash (or (get-mvn-hash latest zip-hash)
+                                 (do (println "Using previous mvnHash (likely unchanged)")
+                                     "sha256-zoRBD41qnaV/XP9qwEYxFdn2JH6LR9udDCCTsYacY74="))
+                    updated-versions (update-versions-content versions-content latest zip-hash mvn-hash)]
+                (spit versions-path updated-versions)
+                (println "Updated versions.nix")
+
+                (println "Updating README.md...")
+                (let [readme-path "README.md"
+                      readme-content (slurp readme-path)
+                      updated-readme (update-readme-content readme-content existing-versions existing-peer-versions latest)]
+                  (spit readme-path updated-readme)
+                  (println "Updated README.md"))
+
+                (println "Updating CHANGELOG.md...")
+                (let [changelog-path "CHANGELOG.md"
+                      changelog-content (slurp changelog-path)
+                      flake-version (next-flake-version changelog-content)
+                      updated-changelog (update-changelog-content changelog-content
+                                                                  flake-version
+                                                                  latest
+                                                                  existing-versions
+                                                                  existing-peer-versions
+                                                                  (today-date))]
+                  (spit changelog-path updated-changelog)
+                  (println "Updated CHANGELOG.md"))
+
+                (println "Updating nixos-modules/datomic-pro.nix...")
+                (let [module-path "nixos-modules/datomic-pro.nix"
+                      module-content (slurp module-path)
+                      all-versions (distinct (cons latest existing-versions))
+                      updated-module (update-nixos-module-content module-content all-versions)]
+                  (spit module-path updated-module)
+                  (println "Updated nixos-modules/datomic-pro.nix"))
+
+                (when build?
+                  (println "Building packages to verify...")
+                  (shell "nix" "build" ".#datomic-pro")
+                  (println "datomic-pro built successfully")
+                  (shell "nix" "build" ".#datomic-pro-peer")
+                  (println "datomic-pro-peer built successfully")
+                  (shell "nix" "build" ".#datomic-pro-container" "-o" "container")
+                  (println "Container image built successfully"))
+
+                (println "Done!")))))))))

--- a/scripts/release_test.clj
+++ b/scripts/release_test.clj
@@ -1,0 +1,136 @@
+(ns release-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [release]))
+
+(deftest version->attr-test
+  (testing "converts version string to nix attribute format"
+    (is (= "1_0_7482" (release/version->attr "1.0.7482")))
+    (is (= "1_0_7469" (release/version->attr "1.0.7469")))))
+
+(deftest datomic-pro-entry-test
+  (testing "generates datomic-pro nix entry"
+    (let [entry (release/datomic-pro-entry "1.0.7500" "sha256-abc123=")]
+      (is (str/includes? entry "datomic-pro_1_0_7500"))
+      (is (str/includes? entry "version = \"1.0.7500\""))
+      (is (str/includes? entry "hash = \"sha256-abc123=\"")))))
+
+(deftest datomic-peer-entry-test
+  (testing "generates datomic-pro-peer nix entry"
+    (let [entry (release/datomic-peer-entry "1.0.7500" "sha256-mvn=" "sha256-zip=")]
+      (is (str/includes? entry "datomic-pro-peer_1_0_7500"))
+      (is (str/includes? entry "version = \"1.0.7500\""))
+      (is (str/includes? entry "mvnHash = \"sha256-mvn=\""))
+      (is (str/includes? entry "zipHash = \"sha256-zip=\"")))))
+
+(deftest extract-versions-test
+  (testing "extracts versions from versions.nix content"
+    (let [content "{ pkgs, ... }:
+rec {
+  datomic-pro_1_0_7482 = pkgs.callPackage ./datomic-pro.nix {
+    version = \"1.0.7482\";
+  };
+  datomic-pro_1_0_7469 = pkgs.callPackage ./datomic-pro.nix {
+    version = \"1.0.7469\";
+  };
+  datomic-pro = datomic-pro_1_0_7482;
+}"
+          versions (release/extract-versions content)]
+      (is (= ["1.0.7482" "1.0.7469"] versions)))))
+
+(deftest extract-peer-versions-test
+  (testing "extracts peer versions from versions.nix content"
+    (let [content "{ pkgs, ... }:
+rec {
+  datomic-pro-peer_1_0_7482 = pkgs.callPackage ./datomic-pro-peer.nix {};
+  datomic-pro-peer_1_0_7469 = pkgs.callPackage ./datomic-pro-peer.nix {};
+  datomic-pro-peer = datomic-pro-peer_1_0_7482;
+}"
+          versions (release/extract-peer-versions content)]
+      (is (= ["1.0.7482" "1.0.7469"] versions)))))
+
+(deftest next-flake-version-test
+  (testing "increments minor version"
+    (is (= "v0.11.0" (release/next-flake-version "## [UNRELEASED]\n\n## v0.10.0 (2026-02-03)")))
+    (is (= "v0.10.0" (release/next-flake-version "## [UNRELEASED]\n\n## v0.9.0 (2025-12-14)")))
+    (is (= "v1.1.0" (release/next-flake-version "## [UNRELEASED]\n\n## v1.0.0 (2026-01-01)")))))
+
+(deftest generate-changelog-entry-test
+  (testing "generates proper changelog entry"
+    (let [entry (release/generate-changelog-entry "v0.11.0" "1.0.7500"
+                                                  ["1.0.7482" "1.0.7469"]
+                                                  ["1.0.7482" "1.0.7469"]
+                                                  "2026-02-03")]
+      (is (str/includes? entry "## v0.11.0 (2026-02-03)"))
+      (is (str/includes? entry "version 1.0.7500"))
+      (is (str/includes? entry "datomic-pro_1_0_7500` (latest)"))
+      (is (str/includes? entry "datomic-pro_1_0_7482`"))
+      (is (str/includes? entry "datomic-pro-peer_1_0_7500` (latest)"))
+      (is (str/includes? entry "datomic-pro-peer_1_0_7482`")))))
+
+(deftest update-changelog-content-test
+  (testing "inserts new entry after UNRELEASED"
+    (let [original "# Changelog
+
+## [UNRELEASED]
+
+## v0.10.0 (2026-02-03)
+
+Previous content here."
+          updated (release/update-changelog-content original "v0.11.0" "1.0.7500"
+                                                    ["1.0.7482"] ["1.0.7482"] "2026-02-04")]
+      (is (str/includes? updated "## [UNRELEASED]"))
+      (is (str/includes? updated "## v0.11.0 (2026-02-04)"))
+      (is (str/includes? updated "## v0.10.0 (2026-02-03)"))
+      (is (< (.indexOf updated "UNRELEASED")
+             (.indexOf updated "v0.11.0")
+             (.indexOf updated "v0.10.0"))))))
+
+(deftest update-versions-content-test
+  (testing "adds new version entries and updates aliases"
+    (let [original "{ pkgs, ... }:
+rec {
+  # Note: the latest version must be the first one in this file
+  datomic-pro_1_0_7482 = pkgs.callPackage ./datomic-pro.nix {
+    version = \"1.0.7482\";
+    hash = \"sha256-old=\";
+  };
+  datomic-pro = datomic-pro_1_0_7482;
+  datomic-pro-peer_1_0_7482 = pkgs.callPackage ./datomic-pro-peer.nix {
+    version = \"1.0.7482\";
+    mvnHash = \"sha256-mvn=\";
+    zipHash = \"sha256-old=\";
+  };
+  datomic-pro-peer = datomic-pro-peer_1_0_7482;
+}"
+          updated (release/update-versions-content original "1.0.7500" "sha256-new=" "sha256-newmvn=")]
+      (is (str/includes? updated "datomic-pro_1_0_7500"))
+      (is (str/includes? updated "datomic-pro = datomic-pro_1_0_7500;"))
+      (is (str/includes? updated "datomic-pro-peer_1_0_7500"))
+      (is (str/includes? updated "datomic-pro-peer = datomic-pro-peer_1_0_7500;"))
+      (is (< (.indexOf updated "datomic-pro_1_0_7500")
+             (.indexOf updated "datomic-pro_1_0_7482"))))))
+
+(deftest update-readme-content-test
+  (testing "updates version lists and docker tags"
+    (let [original "`pkgs.datomic-pro` will always be the latest release, but the following specific versions are also available:
+
+-  `pkgs.datomic-pro_1_0_7482` (latest)
+-  `pkgs.datomic-pro_1_0_7469`
+
+And for peer:
+
+-  `pkgs.datomic-pro-peer_1_0_7482` (latest)
+-  `pkgs.datomic-pro-peer_1_0_7469`
+
+docker pull ghcr.io/outskirtslabs/datomic-pro:1.0.7482
+
+package = pkgs.datomic-pro_1_0_7482;"
+          updated (release/update-readme-content original
+                                                 ["1.0.7482" "1.0.7469"]
+                                                 ["1.0.7482" "1.0.7469"]
+                                                 "1.0.7500")]
+      (is (str/includes? updated "datomic-pro_1_0_7500` (latest)"))
+      (is (str/includes? updated "datomic-pro-peer_1_0_7500` (latest)"))
+      (is (str/includes? updated "ghcr.io/outskirtslabs/datomic-pro:1.0.7500"))
+      (is (str/includes? updated "package = pkgs.datomic-pro_1_0_7500;")))))

--- a/tests/nixos-module.nix
+++ b/tests/nixos-module.nix
@@ -44,6 +44,7 @@ makeTest {
         };
         services.datomic-pro = {
           enable = true;
+          package = datomic-pro;
           secretsFile = "/etc/datomic-pro/do-not-do-this.properties";
           settings = {
             host = "localhost";


### PR DESCRIPTION
## Summary

- Make NixOS module `package` option required (BREAKING)
- Add automatic version bumping with babashka scripts and GitHub Actions

## Breaking Changes

The `services.datomic-pro.package` option is now required. You must explicitly pin your Datomic version. This prevents unexpected upgrades that could affect your data.

## Automatic Updates

- Daily check for new Datomic versions at 8am UTC
- Creates PRs automatically with `auto-update` label
- Auto-tags releases when PRs are merged

## Files Added

- `bb.edn` - Babashka task definitions
- `scripts/release.clj` - Release automation script
- `scripts/release_test.clj` - Test suite
- `.github/workflows/update-datomic.yml` - Daily version check workflow
- `.github/workflows/auto-tag.yml` - Auto-tag on PR merge

Thanks to @licht1stein for the initial contribution.