### PR TITLE
Fix release script hash prefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 ️ This flake exposes:
 
 * A `datomic-pro` nix package (and `console`, and `peer`)
-* ❄ NixOS modules for running Datomic Pro on NixOS
-* 🐋 A container image that you can use to run Datomic Pro (no nix required!)
+* NixOS modules for running Datomic Pro on NixOS
+* A container image that you can use to run Datomic Pro (no nix required!)
 
 All of the above are [end-to-end tested](./tests) by the CI suite in this repo!
 
-**Project status:** Experimental but ready for testing. Breaking changes may occur until version 1.0. The 1.0 release will be considered production-ready.
+**Project status:** Actively used in production, but still pre-1.0. Breaking changes may occur until version 1.0. The 1.0 release will be considered production-ready. [Experience reports welcome](https://casey.link/about#contact).
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**

--- a/scripts/release.clj
+++ b/scripts/release.clj
@@ -25,7 +25,7 @@
                     version version)
         {:keys [out exit]}
         (shell {:out :string :err :string}
-               "nix-prefetch-url" "--type" "sha256" url)]
+               "nix-prefetch-url" "--unpack" "--type" "sha256" url)]
     (when (zero? exit)
       (let [base32-hash (str/trim out)
             {:keys [out exit]}


### PR DESCRIPTION
## Summary

Fix the hash mismatch error in the automated release workflow.

## Problem

The `prefetch-hash` function in `scripts/release.clj` was using `nix-prefetch-url` without the `--unpack` flag. This gave the hash of the raw zip file, but `fetchzip` in the nix package unpacks the archive before hashing, resulting in a mismatch.

## Fix

Added `--unpack` flag to `nix-prefetch-url` so it hashes the unpacked contents, matching what `fetchzip` expects.

## Also includes

- Updated project status in README to reflect production use