### PR TITLE
Add id-token permission for FlakeHub cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          determinate: true
+      - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/flakehub-cache-action@main
       - uses: DeterminateSystems/flake-checker-action@main
       - name: Build datomic-pro nix package

--- a/.github/workflows/update-datomic.yml
+++ b/.github/workflows/update-datomic.yml
@@ -10,6 +10,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     steps:


### PR DESCRIPTION
Add missing id-token: write permission required for FlakeHub cache authentication via OIDC.