### PR TITLE
Make CI tag input optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       tag:
         description: "The existing tag to publish to FlakeHub"
         type: "string"
-        required: true
+        required: false
 
 jobs:
   check:


### PR DESCRIPTION
Allow workflow_dispatch without tag for triggering CI on PR branches.