### PR TITLE
add actions write permission to update workflow

### DIFF
--- a/.github/workflows/update-datomic.yml
+++ b/.github/workflows/update-datomic.yml
@@ -13,6 +13,7 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@v3


### PR DESCRIPTION
Fixes the 403 error when triggering CI workflow from the auto-update workflow.