### PR TITLE
trigger ci workflow on tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,13 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
+    paths-ignore:
+      - '.github/workflows/**'
   pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Fixes publish job not running - workflow wasn't triggering on tag pushes.