### PR TITLE
remove paths-ignore from push trigger to fix tag publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
       - main
     tags:
       - 'v*'
-    paths-ignore:
-      - '.github/workflows/**'
   pull_request:
     paths-ignore:
       - '.github/workflows/**'


### PR DESCRIPTION
paths-ignore on push was preventing tag pushes from triggering the workflow. Keep it only on pull_request.