### PR TITLE
Datomic Pro 1.0.7622

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,8 +7,6 @@ Versioning*].
 
 == [UNRELEASED]
 
-== v0.14.0 (2026-04-29)
-
 This is a version bump release:
 
 * Added package versions for

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,38 @@ Versioning*].
 
 == [UNRELEASED]
 
+== v0.14.0 (2026-04-29)
+
+This is a version bump release:
+
+* Added package versions for
+https://docs.datomic.com/changes/pro.html#1.0.7622[version 1.0.7622]
+
+`pkgs.datomic-pro` will always be the latest release, but the following
+specific versions are also available:
+
+* `pkgs.datomic-pro_1_0_7622` (latest)
+* `pkgs.datomic-pro_1_0_7556`
+* `pkgs.datomic-pro_1_0_7491`
+* `pkgs.datomic-pro_1_0_7482`
+* `pkgs.datomic-pro_1_0_7469`
+* `pkgs.datomic-pro_1_0_7394`
+* `pkgs.datomic-pro_1_0_7387`
+* `pkgs.datomic-pro_1_0_7364`
+* `pkgs.datomic-pro_1_0_7277`
+
+And for peer:
+
+* `pkgs.datomic-pro-peer_1_0_7622` (latest)
+* `pkgs.datomic-pro-peer_1_0_7556`
+* `pkgs.datomic-pro-peer_1_0_7491`
+* `pkgs.datomic-pro-peer_1_0_7482`
+* `pkgs.datomic-pro-peer_1_0_7469`
+* `pkgs.datomic-pro-peer_1_0_7394`
+* `pkgs.datomic-pro-peer_1_0_7387`
+* `pkgs.datomic-pro-peer_1_0_7364`
+* `pkgs.datomic-pro-peer_1_0_7277`
+
 == v0.13.0 (2026-04-01)
 
 This is a version bump release:

--- a/doc/modules/ROOT/pages/changelog.adoc
+++ b/doc/modules/ROOT/pages/changelog.adoc
@@ -7,8 +7,6 @@ Versioning*].
 
 == [UNRELEASED]
 
-== v0.14.0 (2026-04-29)
-
 This is a version bump release:
 
 * Added package versions for

--- a/doc/modules/ROOT/pages/changelog.adoc
+++ b/doc/modules/ROOT/pages/changelog.adoc
@@ -7,6 +7,38 @@ Versioning*].
 
 == [UNRELEASED]
 
+== v0.14.0 (2026-04-29)
+
+This is a version bump release:
+
+* Added package versions for
+https://docs.datomic.com/changes/pro.html#1.0.7622[version 1.0.7622]
+
+`pkgs.datomic-pro` will always be the latest release, but the following
+specific versions are also available:
+
+* `pkgs.datomic-pro_1_0_7622` (latest)
+* `pkgs.datomic-pro_1_0_7556`
+* `pkgs.datomic-pro_1_0_7491`
+* `pkgs.datomic-pro_1_0_7482`
+* `pkgs.datomic-pro_1_0_7469`
+* `pkgs.datomic-pro_1_0_7394`
+* `pkgs.datomic-pro_1_0_7387`
+* `pkgs.datomic-pro_1_0_7364`
+* `pkgs.datomic-pro_1_0_7277`
+
+And for peer:
+
+* `pkgs.datomic-pro-peer_1_0_7622` (latest)
+* `pkgs.datomic-pro-peer_1_0_7556`
+* `pkgs.datomic-pro-peer_1_0_7491`
+* `pkgs.datomic-pro-peer_1_0_7482`
+* `pkgs.datomic-pro-peer_1_0_7469`
+* `pkgs.datomic-pro-peer_1_0_7394`
+* `pkgs.datomic-pro-peer_1_0_7387`
+* `pkgs.datomic-pro-peer_1_0_7364`
+* `pkgs.datomic-pro-peer_1_0_7277`
+
 == v0.13.0 (2026-04-01)
 
 This is a version bump release:

--- a/doc/modules/ROOT/pages/docker-oci-container.adoc
+++ b/doc/modules/ROOT/pages/docker-oci-container.adoc
@@ -10,7 +10,7 @@ If you do not want to build with nix, pull a published image:
 
 [source,shell]
 ----
-docker pull ghcr.io/outskirtslabs/datomic-pro:1.0.7556
+docker pull ghcr.io/outskirtslabs/datomic-pro:1.0.7622
 ----
 
 Package tags are listed at:
@@ -87,7 +87,7 @@ Run with `console` as the first argument.
 ---
 services:
   datomic-transactor:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7556
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
     environment:
       DATOMIC_STORAGE_ADMIN_PASSWORD: unsafe
       DATOMIC_STORAGE_DATOMIC_PASSWORD: unsafe
@@ -97,7 +97,7 @@ services:
       - 127.0.0.1:4334:4334
 
   datomic-console:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7556
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
     command: console
     environment:
       DB_URI: datomic:dev://datomic-transactor:4334/?password=unsafe
@@ -185,7 +185,7 @@ services:
     restart: always
 
   datomic-storage-migrator:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7556
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
     environment:
       PGUSER: postgres
       PGPASSWORD: unsafe
@@ -198,7 +198,7 @@ services:
              (psql -h datomic-storage -d datomic -c "\\du" | cut -d \| -f 1 | grep -qw "datomic" || psql -h datomic-storage -d datomic -f /opt/datomic-pro/bin/sql/postgres-user.sql)'
 
   datomic-transactor:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7556
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
     environment:
       DATOMIC_STORAGE_ADMIN_PASSWORD: unsafe
       DATOMIC_STORAGE_DATOMIC_PASSWORD: unsafe
@@ -212,7 +212,7 @@ services:
     restart: always
 
   datomic-console:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7556
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
     command: console
     environment:
       DB_URI: datomic:sql://?jdbc:postgresql://datomic-storage:5432/datomic?user=datomic&password=datomic

--- a/doc/modules/ROOT/pages/nixos-module.adoc
+++ b/doc/modules/ROOT/pages/nixos-module.adoc
@@ -61,7 +61,7 @@ A basic dev-mode transactor storing data under `/var/lib/datomic-pro`:
 {
   services.datomic-pro = {
     enable = true;
-    package = pkgs.datomic-pro_1_0_7556;
+    package = pkgs.datomic-pro_1_0_7622;
     secretsFile = "/etc/datomic-pro/secrets.properties";
     settings = {
       host = "localhost";
@@ -88,13 +88,26 @@ A basic dev-mode transactor storing data under `/var/lib/datomic-pro`:
 
 Specific versions are also exposed, for example:
 
+* `pkgs.datomic-pro_1_0_7622` (latest)
 * `pkgs.datomic-pro_1_0_7556`
 * `pkgs.datomic-pro_1_0_7491`
 * `pkgs.datomic-pro_1_0_7482`
 * `pkgs.datomic-pro_1_0_7469`
+* `pkgs.datomic-pro_1_0_7394`
+* `pkgs.datomic-pro_1_0_7387`
+* `pkgs.datomic-pro_1_0_7364`
+* `pkgs.datomic-pro_1_0_7277`
+
+And for peer:
+
+* `pkgs.datomic-pro-peer_1_0_7622` (latest)
 * `pkgs.datomic-pro-peer_1_0_7556`
 * `pkgs.datomic-pro-peer_1_0_7491`
 * `pkgs.datomic-pro-peer_1_0_7482`
 * `pkgs.datomic-pro-peer_1_0_7469`
+* `pkgs.datomic-pro-peer_1_0_7394`
+* `pkgs.datomic-pro-peer_1_0_7387`
+* `pkgs.datomic-pro-peer_1_0_7364`
+* `pkgs.datomic-pro-peer_1_0_7277`
 
 New upstream Datomic releases are typically added within 24 hours.

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1752411349,
-        "narHash": "sha256-yLJ0zJDA+n4gVBxwrNdFlYGIswurnlGQVYfmfNz7+ZE=",
+        "lastModified": 1773151887,
+        "narHash": "sha256-YUiehwe2iTlwYSrnJ1pcw7KDNX+U42xlTx/2k/mo0P8=",
         "owner": "jlesquembre",
         "repo": "clj-nix",
-        "rev": "0936e832f4c74126a31740bf36d3d3f243024a03",
+        "rev": "27dac4466c9d3939f6a4925bc09e0cb1d8f32d9c",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741473158,
-        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728229178,
-        "narHash": "sha256-p5Fx880uBYstIsbaDYN7sECJT11oHxZQKtHgMAVblWA=",
+        "lastModified": 1755022803,
+        "narHash": "sha256-/QtBdVfZlrRJW5enUoWlBE2wrLXJBMJ45X0rZh0jiaU=",
         "owner": "jlesquembre",
         "repo": "nix-fetcher-data",
-        "rev": "f3a73c34d28db49ef90fd7872a142bfe93120e55",
+        "rev": "9da3926b1459d6ff15268072d1c51351b82811b9",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
         "type": "github"
       },
       "original": {
@@ -182,11 +182,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1755268003,
-        "narHash": "sha256-nNaeJjo861wFR0tjHDyCnHs1rbRtrMgxAKMoig9Sj/w=",
+        "lastModified": 1775639890,
+        "narHash": "sha256-9O9gNidrdzcb7vgKGtff7QiLtr0IsVaCi0pAXm8anhQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32f313e49e42f715491e1ea7b306a87c16fe0388",
+        "rev": "456e8a9468b9d46bd8c9524425026c00745bc4d2",
         "type": "github"
       },
       "original": {

--- a/nixos-modules/datomic-pro.nix
+++ b/nixos-modules/datomic-pro.nix
@@ -33,12 +33,12 @@ in
           to ensure you explicitly pin your Datomic version and avoid unexpected upgrades.
         '';
         relatedPackages = [
+          "datomic-pro_1_0_7622"
           "datomic-pro_1_0_7556"
           "datomic-pro_1_0_7491"
           "datomic-pro_1_0_7482"
           "datomic-pro_1_0_7469"
           "datomic-pro_1_0_7394"
-          "datomic-pro_1_0_7387"
         ];
       };
       secretsFile = lib.mkOption {

--- a/pkgs/versions.nix
+++ b/pkgs/versions.nix
@@ -2,6 +2,10 @@
 rec {
   # Note: the latest version must be the first one in this file
   #       because the ci pipeline detects the "current" version that way
+  datomic-pro_1_0_7622 = pkgs.callPackage ./datomic-pro.nix {
+    version = "1.0.7622";
+    hash = "sha256-65d5ht5NeIHyBNExOR5cCR8fgqHcoc8i1v+m4eMviZ8=";
+  };
   datomic-pro_1_0_7556 = pkgs.callPackage ./datomic-pro.nix {
     version = "1.0.7556";
     hash = "sha256-wCQ7obE3P+IlTrwW4SoEoGnMcEMo5C+4p/Y4y2O4NF8=";
@@ -34,7 +38,12 @@ rec {
     version = "1.0.7277";
     hash = "sha256-fqmw+MOUWPCAhHMROjP48BwWCcRknk+KECM3WvF/Ml4=";
   };
-  datomic-pro = datomic-pro_1_0_7556;
+  datomic-pro = datomic-pro_1_0_7622;
+  datomic-pro-peer_1_0_7622 = pkgs.callPackage ./datomic-pro-peer.nix {
+    version = "1.0.7622";
+    mvnHash = "sha256-+iVSXK/ecFR9IqSGPZr06ogWm+BMWpSOWqYh34YHJHo=";
+    zipHash = "sha256-65d5ht5NeIHyBNExOR5cCR8fgqHcoc8i1v+m4eMviZ8=";
+  };
   datomic-pro-peer_1_0_7556 = pkgs.callPackage ./datomic-pro-peer.nix {
     version = "1.0.7556";
     mvnHash = "sha256-+iVSXK/ecFR9IqSGPZr06ogWm+BMWpSOWqYh34YHJHo=";
@@ -75,5 +84,5 @@ rec {
     mvnHash = "sha256-09AKaahc4MSc0d/gWJyMpB60O7WZOauj7vS1X4rtPjI=";
     zipHash = "sha256-fqmw+MOUWPCAhHMROjP48BwWCcRknk+KECM3WvF/Ml4=";
   };
-  datomic-pro-peer = datomic-pro-peer_1_0_7556;
+  datomic-pro-peer = datomic-pro-peer_1_0_7622;
 }


### PR DESCRIPTION

- Add Datomic Pro and peer package entries for 1.0.7622.
- Update latest aliases, module related packages, docs, Docker examples, and changelog.
