### PR TITLE
Add datomic-pro: 1.0.7705

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,7 +7,41 @@ Versioning*].
 
 == [UNRELEASED]
 
+== v0.15.0 (2026-07-13)
+
 * The flake is now tracking nixpkgs stable 26.05
+
+This is a version bump release:
+
+* Added package versions for
+https://docs.datomic.com/changes/pro.html#1.0.7705[version 1.0.7705]
+
+`pkgs.datomic-pro` will always be the latest release, but the following
+specific versions are also available:
+
+* `pkgs.datomic-pro_1_0_7705` (latest)
+* `pkgs.datomic-pro_1_0_7622`
+* `pkgs.datomic-pro_1_0_7556`
+* `pkgs.datomic-pro_1_0_7491`
+* `pkgs.datomic-pro_1_0_7482`
+* `pkgs.datomic-pro_1_0_7469`
+* `pkgs.datomic-pro_1_0_7394`
+* `pkgs.datomic-pro_1_0_7387`
+* `pkgs.datomic-pro_1_0_7364`
+* `pkgs.datomic-pro_1_0_7277`
+
+And for peer:
+
+* `pkgs.datomic-pro-peer_1_0_7705` (latest)
+* `pkgs.datomic-pro-peer_1_0_7622`
+* `pkgs.datomic-pro-peer_1_0_7556`
+* `pkgs.datomic-pro-peer_1_0_7491`
+* `pkgs.datomic-pro-peer_1_0_7482`
+* `pkgs.datomic-pro-peer_1_0_7469`
+* `pkgs.datomic-pro-peer_1_0_7394`
+* `pkgs.datomic-pro-peer_1_0_7387`
+* `pkgs.datomic-pro-peer_1_0_7364`
+* `pkgs.datomic-pro-peer_1_0_7277`
 
 == v0.14.0 (2026-04-29)
 

--- a/doc/modules/ROOT/pages/changelog.adoc
+++ b/doc/modules/ROOT/pages/changelog.adoc
@@ -7,7 +7,41 @@ Versioning*].
 
 == [UNRELEASED]
 
+== v0.15.0 (2026-07-13)
+
 * The flake is now tracking nixpkgs stable 26.05
+
+This is a version bump release:
+
+* Added package versions for
+https://docs.datomic.com/changes/pro.html#1.0.7705[version 1.0.7705]
+
+`pkgs.datomic-pro` will always be the latest release, but the following
+specific versions are also available:
+
+* `pkgs.datomic-pro_1_0_7705` (latest)
+* `pkgs.datomic-pro_1_0_7622`
+* `pkgs.datomic-pro_1_0_7556`
+* `pkgs.datomic-pro_1_0_7491`
+* `pkgs.datomic-pro_1_0_7482`
+* `pkgs.datomic-pro_1_0_7469`
+* `pkgs.datomic-pro_1_0_7394`
+* `pkgs.datomic-pro_1_0_7387`
+* `pkgs.datomic-pro_1_0_7364`
+* `pkgs.datomic-pro_1_0_7277`
+
+And for peer:
+
+* `pkgs.datomic-pro-peer_1_0_7705` (latest)
+* `pkgs.datomic-pro-peer_1_0_7622`
+* `pkgs.datomic-pro-peer_1_0_7556`
+* `pkgs.datomic-pro-peer_1_0_7491`
+* `pkgs.datomic-pro-peer_1_0_7482`
+* `pkgs.datomic-pro-peer_1_0_7469`
+* `pkgs.datomic-pro-peer_1_0_7394`
+* `pkgs.datomic-pro-peer_1_0_7387`
+* `pkgs.datomic-pro-peer_1_0_7364`
+* `pkgs.datomic-pro-peer_1_0_7277`
 
 == v0.14.0 (2026-04-29)
 

--- a/doc/modules/ROOT/pages/docker-oci-container.adoc
+++ b/doc/modules/ROOT/pages/docker-oci-container.adoc
@@ -10,7 +10,7 @@ If you do not want to build with nix, pull a published image:
 
 [source,shell]
 ----
-docker pull ghcr.io/outskirtslabs/datomic-pro:1.0.7622
+docker pull ghcr.io/outskirtslabs/datomic-pro:1.0.7705
 ----
 
 Package tags are listed at:
@@ -87,7 +87,7 @@ Run with `console` as the first argument.
 ---
 services:
   datomic-transactor:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7705
     environment:
       DATOMIC_STORAGE_ADMIN_PASSWORD: unsafe
       DATOMIC_STORAGE_DATOMIC_PASSWORD: unsafe
@@ -97,7 +97,7 @@ services:
       - 127.0.0.1:4334:4334
 
   datomic-console:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7705
     command: console
     environment:
       DB_URI: datomic:dev://datomic-transactor:4334/?password=unsafe
@@ -185,7 +185,7 @@ services:
     restart: always
 
   datomic-storage-migrator:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7705
     environment:
       PGUSER: postgres
       PGPASSWORD: unsafe
@@ -198,7 +198,7 @@ services:
              (psql -h datomic-storage -d datomic -c "\\du" | cut -d \| -f 1 | grep -qw "datomic" || psql -h datomic-storage -d datomic -f /opt/datomic-pro/bin/sql/postgres-user.sql)'
 
   datomic-transactor:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7705
     environment:
       DATOMIC_STORAGE_ADMIN_PASSWORD: unsafe
       DATOMIC_STORAGE_DATOMIC_PASSWORD: unsafe
@@ -212,7 +212,7 @@ services:
     restart: always
 
   datomic-console:
-    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7622
+    image: ghcr.io/outskirtslabs/datomic-pro:1.0.7705
     command: console
     environment:
       DB_URI: datomic:sql://?jdbc:postgresql://datomic-storage:5432/datomic?user=datomic&password=datomic

--- a/doc/modules/ROOT/pages/nixos-module.adoc
+++ b/doc/modules/ROOT/pages/nixos-module.adoc
@@ -61,7 +61,7 @@ A basic dev-mode transactor storing data under `/var/lib/datomic-pro`:
 {
   services.datomic-pro = {
     enable = true;
-    package = pkgs.datomic-pro_1_0_7622;
+    package = pkgs.datomic-pro_1_0_7705;
     secretsFile = "/etc/datomic-pro/secrets.properties";
     settings = {
       host = "localhost";
@@ -88,7 +88,8 @@ A basic dev-mode transactor storing data under `/var/lib/datomic-pro`:
 
 Specific versions are also exposed, for example:
 
-* `pkgs.datomic-pro_1_0_7622` (latest)
+* `pkgs.datomic-pro_1_0_7705` (latest)
+* `pkgs.datomic-pro_1_0_7622`
 * `pkgs.datomic-pro_1_0_7556`
 * `pkgs.datomic-pro_1_0_7491`
 * `pkgs.datomic-pro_1_0_7482`
@@ -100,7 +101,8 @@ Specific versions are also exposed, for example:
 
 And for peer:
 
-* `pkgs.datomic-pro-peer_1_0_7622` (latest)
+* `pkgs.datomic-pro-peer_1_0_7705` (latest)
+* `pkgs.datomic-pro-peer_1_0_7622`
 * `pkgs.datomic-pro-peer_1_0_7556`
 * `pkgs.datomic-pro-peer_1_0_7491`
 * `pkgs.datomic-pro-peer_1_0_7482`

--- a/nixos-modules/datomic-pro.nix
+++ b/nixos-modules/datomic-pro.nix
@@ -33,12 +33,11 @@ in
           to ensure you explicitly pin your Datomic version and avoid unexpected upgrades.
         '';
         relatedPackages = [
+          "datomic-pro_1_0_7705"
           "datomic-pro_1_0_7622"
           "datomic-pro_1_0_7556"
           "datomic-pro_1_0_7491"
           "datomic-pro_1_0_7482"
-          "datomic-pro_1_0_7469"
-          "datomic-pro_1_0_7394"
         ];
       };
       secretsFile = lib.mkOption {

--- a/pkgs/versions.nix
+++ b/pkgs/versions.nix
@@ -2,6 +2,10 @@
 rec {
   # Note: the latest version must be the first one in this file
   #       because the ci pipeline detects the "current" version that way
+  datomic-pro_1_0_7705 = pkgs.callPackage ./datomic-pro.nix {
+    version = "1.0.7705";
+    hash = "sha256-r7y17d4dufLfKJB7gv8feTLlvs1nuoRU2/TueR9wd9I=";
+  };
   datomic-pro_1_0_7622 = pkgs.callPackage ./datomic-pro.nix {
     version = "1.0.7622";
     hash = "sha256-65d5ht5NeIHyBNExOR5cCR8fgqHcoc8i1v+m4eMviZ8=";
@@ -38,7 +42,12 @@ rec {
     version = "1.0.7277";
     hash = "sha256-fqmw+MOUWPCAhHMROjP48BwWCcRknk+KECM3WvF/Ml4=";
   };
-  datomic-pro = datomic-pro_1_0_7622;
+  datomic-pro = datomic-pro_1_0_7705;
+  datomic-pro-peer_1_0_7705 = pkgs.callPackage ./datomic-pro-peer.nix {
+    version = "1.0.7705";
+    mvnHash = "sha256-9HNgZvrOlgKlXvCBl/p0mx/foBzQL+3c/GhNKDnwNB4=";
+    zipHash = "sha256-r7y17d4dufLfKJB7gv8feTLlvs1nuoRU2/TueR9wd9I=";
+  };
   datomic-pro-peer_1_0_7622 = pkgs.callPackage ./datomic-pro-peer.nix {
     version = "1.0.7622";
     mvnHash = "sha256-+iVSXK/ecFR9IqSGPZr06ogWm+BMWpSOWqYh34YHJHo=";
@@ -84,5 +93,5 @@ rec {
     mvnHash = "sha256-09AKaahc4MSc0d/gWJyMpB60O7WZOauj7vS1X4rtPjI=";
     zipHash = "sha256-fqmw+MOUWPCAhHMROjP48BwWCcRknk+KECM3WvF/Ml4=";
   };
-  datomic-pro-peer = datomic-pro-peer_1_0_7622;
+  datomic-pro-peer = datomic-pro-peer_1_0_7705;
 }


### PR DESCRIPTION
## Summary

- Add Datomic Pro 1.0.7705 (upstream release date: 2026-07-10) for both the
  transactor and peer packages, with verified fixed-output hashes.
- Make the unversioned aliases select 1.0.7705 and update NixOS metadata,
  package lists, configuration examples, and stable OCI tags.
- Prepare flake release v0.15.0, preserve the existing nixpkgs 26.05 note, and
  regenerate the Antora changelog.

## Validation

- [x] `nix develop --command bb test` — 11 tests, 38 assertions
- [x] Versioned transactor and peer builds
- [x] Stable and unstable OCI image builds and manifest inspection
- [x] `nix flake check --print-build-logs` — all 247 host-compatible checks,
  including module and container VMs
- [x] Final `bb gen-docs` reproducibility pass
- [x] `git diff --check` and source/generated document equality
- [x] Independent read-only release diff review

## Release boundary

This PR is intentionally a draft for manual human review. Do not merge it until
explicit approval: merging a matching PR triggers creation of the `v0.15.0`
tag and GitHub release, followed by OCI and FlakeHub publication.
